### PR TITLE
Add a method for creating a cellSet directly from cellIds

### DIFF
--- a/src/ExpressionMatrix.cpp
+++ b/src/ExpressionMatrix.cpp
@@ -1738,6 +1738,16 @@ bool ExpressionMatrix::createCellSetUsingMetaData(
     return true;
 }
 
+// Create a new cell set using a vector of cellIds.
+bool ExpressionMatrix::createCellSet(const string& cellSetName, vector<CellId>& cellIds)
+{
+    if(cellSets.exists(cellSetName)) {
+        cout << "Cell set " << cellSetName << " already exists." << endl;
+        return false;
+    }
+    cellSets.addCellSet(cellSetName, cellIds);
+    return true;
+};
 
 
 

--- a/src/ExpressionMatrix.hpp
+++ b/src/ExpressionMatrix.hpp
@@ -886,6 +886,11 @@ public:
         bool useRegex                       // true=match as regular expression, false=match as string.
         );
 
+    // Create a new cell set directly, using a vector CellIds.
+    bool createCellSet(
+        const string& cellSetName,
+        vector<CellId>& cellIds
+        );
 
 
     // Create a new cell set consisting of cells for which a given meta data field


### PR DESCRIPTION
This method is helpful for the python (and possible R) API. There are times when I have a list of `CellIds`, and I want to create a `CellSet` out of them so I can use it in `findSimilarPairs`, etc.