### PR TITLE
Add includes for gcc 6.3.0

### DIFF
--- a/src/ExpressionMatrixLsh.cpp
+++ b/src/ExpressionMatrixLsh.cpp
@@ -43,6 +43,7 @@ using namespace ExpressionMatrix2;
 #include <cmath>
 #include "fstream.hpp"
 #include <chrono>
+#include <numeric>
 
 
 // Generate the random unit LSH vectors.

--- a/src/randIndex.hpp
+++ b/src/randIndex.hpp
@@ -16,6 +16,7 @@
 #include "algorithm.hpp"
 #include "CZI_ASSERT.hpp"
 #include "vector.hpp"
+#include <numeric>
 
 namespace ChanZuckerberg {
     namespace ExpressionMatrix2 {


### PR DESCRIPTION
This fixes the build on ubuntu 17.04. The missing numeric includes were
causing it to give errors about std::accumulate.